### PR TITLE
Basic CI Build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - uses: gradle/gradle-build-action@v2
       - name: Build
-        run: ./gradlew :desktopApp:packageReleaseUberStripArchitecture
+        run: ./gradlew :desktopApp:packageReleaseStripArchitecture
       - name: Upload distributable
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Basic workflow for creating a distributable JAR file. We'll keep it simple by generating a JAR file and using it as an artifact for running. The challenge was making sure the JAR works on Apple Silicon architecture since GitHub Actions doesn't support it as a runner. 