### PR TITLE
Fix starfield

### DIFF
--- a/shared/src/commonMain/kotlin/com/bumble/puzzyx/composable/StarFieldMessageBoard.kt
+++ b/shared/src/commonMain/kotlin/com/bumble/puzzyx/composable/StarFieldMessageBoard.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -34,6 +35,7 @@ import com.bumble.puzzyx.model.Entry
 import com.bumble.puzzyx.model.entries
 import com.bumble.puzzyx.ui.appyx_dark
 import kotlinx.coroutines.isActive
+import org.jetbrains.skia.svg.SVGPreserveAspectRatio
 import kotlin.math.max
 import kotlin.math.roundToInt
 import kotlin.random.Random
@@ -56,7 +58,8 @@ private data class Star(
     val xCoord: Float = Random.nextDouble(-0.5, 0.5).toFloat(),
     val yCoord: Float = Random.nextDouble(-0.5, 0.5).toFloat(),
     val zCoord: Float,
-    val size: Modifier,
+    val sizeDp: Dp,
+    val aspectRatio: Float = 1f,
     val type: StarType,
 )
 
@@ -64,13 +67,14 @@ private data class Star(
 private sealed class StarType {
     data class RegularType(val color: Color) : StarType() {
         companion object {
-            val size: Modifier = Modifier.size(4.dp)
+            val sizeDp: Dp = 4.dp
         }
     }
 
     data class EntryType(val entry: Entry) : StarType() {
         companion object {
-            val size: Modifier = Modifier.fillMaxSize(0.15f).aspectRatio(1.5f)
+            val sizeDp: Dp = 260.dp
+            const val aspectRatio: Float = 1.5f
         }
     }
 
@@ -102,7 +106,7 @@ private data class StarField(
                         from = starFieldSpecs.zNewCoord.toDouble(),
                         until = starFieldSpecs.zFadeOutEnd.toDouble(),
                     ).toFloat(),
-                    size = StarType.RegularType.size,
+                    sizeDp = StarType.RegularType.sizeDp,
                     type = StarType.RegularType(
                         color = Color(
                             red = Random.nextDouble(0.60, 0.66).toFloat(),
@@ -117,7 +121,8 @@ private data class StarField(
             entries.reversed().mapIndexed { index, entry ->
                 Star(
                     zCoord = starFieldSpecs.zFadeInStart - index * starFieldSpecs.zOffset,
-                    size = StarType.EntryType.size,
+                    sizeDp = StarType.EntryType.sizeDp,
+                    aspectRatio = StarType.EntryType.aspectRatio,
                     type = StarType.EntryType(entry = entry),
                 )
             }
@@ -193,10 +198,11 @@ private fun StarFieldContent(
                 val alpha = starField.specs.calcAlpha(zPos)
                 if (alpha > 0f) {
                     OptimisingLayout(
-                        optimalWidth = 200.dp,
+                        optimalWidth = star.sizeDp,
                         modifier = Modifier
                             .scale(zPos)
-                            .then(star.size)
+                            .size(star.sizeDp)
+                            .aspectRatio(star.aspectRatio)
                             .align(Alignment.Center)
                             .absoluteOffset {
                                 IntOffset(


### PR DESCRIPTION
After implementing OptimisingLayout, standard stars were no longer visible. There was no distinction in how the `optimalWidth` value was assigned, whether for rendering entries or regular stars.